### PR TITLE
Disable Pushing to Codacy for Forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,7 @@ jobs:
       run: go test ./... -coverprofile=coverage.txt -covermode=atomic
 
     - name: Upload coverage report
+      if: github.repository == 'Spazzy757/paul'
       uses: codecov/codecov-action@v1.0.2
       with:
         token: ${{ secrets.CODCOV_TOKEN }}


### PR DESCRIPTION
# Changelog

- Disabled running Codacy Coverage on Forks
