### PR TITLE
Created handler to copy linked issue labels

### DIFF
--- a/pkg/github/pullrequests.go
+++ b/pkg/github/pullrequests.go
@@ -47,6 +47,10 @@ func PullRequestHandler(
 	if err != nil {
 		return err
 	}
+	err = copyIssueLabels(ctx, cfg, client, event)
+	if err != nil {
+		return err
+	}
 	err = dcoCheck(ctx, cfg, client, event)
 	return err
 }
@@ -175,6 +179,17 @@ func dcoCheck(
 	return nil
 }
 
+//copyIssueLabels
+func copyIssueLabels(
+	ctx context.Context,
+	cfg types.PaulConfig,
+	client *github.Client,
+	event *github.PullRequestEvent,
+
+) error {
+	return nil
+}
+
 //reviewComment sends a review comment to a Pull Request
 func reviewComment(
 	ctx context.Context,
@@ -270,3 +285,5 @@ func mergePullRequest(
 	)
 	return err
 }
+
+//


### PR DESCRIPTION
Signed-off-by: Spazzy <brendankamp757@gmail.com>

# Changelog

- adds the functionality to copy the labels from the linked issues

## Issues

fix: https://github.com/Spazzy757/paul/issues/66
