### PR TITLE
Added dependabot to the frontend

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,14 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-  open-pull-requests-limit: 10
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "04:00"
+    open-pull-requests-limit: 10
+  - package-ecosystem: npm
+    directory: "/web/"
+    schedule:
+      interval: daily
+      time: "04:00"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Signed-off-by: Spazzy <brendankamp757@gmail.com>

# Changelog

- Adds the front end that is in `/web/` to the dependabot

## Issues

fix: https://github.com/Spazzy757/paul/issues/87
