### PR TITLE
Added assign command

### DIFF
--- a/.github/PAUL.yaml
+++ b/.github/PAUL.yaml
@@ -14,6 +14,8 @@ branch_destroyer:
   protected_branches:
     - main
 pull_requests:
+  # Allows use of the /assign command
+  assign: true
   # Enables DCO check on commits
   dco_check: true
   # Enables Verified Commits check on commits

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 # builder image
 FROM golang:1.15-buster as builder
 
-
 RUN mkdir /build
 ADD . /build/
 WORKDIR /build
@@ -15,7 +14,6 @@ ENV GITHUB_SECRET_KEY=$SECRET_KEY
 RUN mkdir /secrets
 RUN echo ${GITHUB_PRIVATE_KEY} | base64 -d > /secrets/paul-private-key
 RUN echo ${GITHUB_SECRET_KEY} > /secrets/paul-secret-key
-
 
 FROM node:lts-alpine as web-builder
 RUN mkdir /web

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Commands:
 - `/dog`: Paul will add and image of a dog
 - `/cat`: Paul will add an Image of a cat
 - `/giphy <some description>`: Paul will fetch a giphy that matches the description and add it to the PR/Issue (only single word descriptions are currently supported)
+- `/assign @Spazzy757 @OtherUser`: Paul will add all users that are in the maintainers lists as reviewers
 
 Other Functions:
 
@@ -59,6 +60,8 @@ branch_destroyer:
   protected_branches:
     - main
 pull_requests:
+  # Enableds the /assign command
+  assign: true
   # The Setting to enable automaed merges
   automated_merge: true
   # The time in days after a PR should be labeled inactive

--- a/mocks/assign-command.json
+++ b/mocks/assign-command.json
@@ -1,0 +1,87 @@
+{
+    "action": "created",
+    "issue": {
+        "id": 111111,
+        "node_id": "dGVzdAo=",
+        "number": 9,
+        "title": "Cleaned up dockerfile",
+        "user": {
+            "login": "Spazzy757",
+            "id": 111111,
+            "node_id": "dGVzdAo=",
+            "type": "User",
+            "site_admin": false
+        },
+        "state": "open",
+        "locked": false,
+        "milestone": null,
+        "closed_at": null,
+        "author_association": "OWNER",
+        "active_lock_reason": null,
+        "pull_request": {},
+        "body": "",
+        "performed_via_github_app": null
+    },
+    "comment": {
+        "id": 111111,
+        "node_id": "dGVzdAo=",
+        "user": {
+            "login": "Spazzy757",
+            "id": 111111,
+            "node_id": "dGVzdAo=",
+            "gravatar_id": "",
+            "type": "User",
+            "site_admin": false
+        },
+        "author_association": "OWNER",
+        "body": "/assign Spazzy757",
+        "performed_via_github_app": null
+    },
+    "repository": {
+        "id": 111111,
+        "node_id": "dGVzdAo=",
+        "name": "paul",
+        "full_name": "Spazzy757/paul",
+        "private": false,
+        "owner": {
+            "login": "Spazzy757",
+            "id": 111111,
+            "node_id": "",
+            "type": "User",
+            "site_admin": false
+        },
+        "description": "The Alien Github Bot ",
+        "fork": false,
+        "homepage": "",
+        "size": 49,
+        "stargazers_count": 0,
+        "watchers_count": 0,
+        "language": "Go",
+        "has_issues": true,
+        "has_projects": true,
+        "has_downloads": true,
+        "has_wiki": true,
+        "has_pages": false,
+        "forks_count": 0,
+        "mirror_url": null,
+        "archived": false,
+        "disabled": false,
+        "open_issues_count": 5,
+        "license": {},
+        "forks": 0,
+        "open_issues": 5,
+        "watchers": 0,
+        "default_branch": "main"
+    },
+    "sender": {
+        "login": "Spazzy757",
+        "id": 111111,
+        "node_id": "dGVzdAo=",
+        "type": "User",
+        "site_admin": false
+    },
+    "installation": {
+        "id": 12256835,
+        "node_id": "dGVzdAo="
+    }
+}

--- a/pkg/github/issue_test.go
+++ b/pkg/github/issue_test.go
@@ -240,7 +240,9 @@ func TestAssignCommand(t *testing.T) {
 			Maintainers: []string{
 				"Spazzy757",
 			},
-			Labels: true,
+			PullRequests: types.PullRequests{
+				Assign: true,
+			},
 		}
 
 		mux.HandleFunc(
@@ -270,7 +272,9 @@ func TestAssignCommand(t *testing.T) {
 			Maintainers: []string{
 				"Test",
 			},
-			Labels: true,
+			PullRequests: types.PullRequests{
+				Assign: true,
+			},
 		}
 
 		mux.HandleFunc(

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -23,6 +23,7 @@ type EmptyDescriptionCheck struct {
 type PullRequests struct {
 	OpenMessage         string            `yaml:"open_message,omitempty"`
 	AllowApproval       bool              `yaml:"allow_approval,omitempty"`
+	Assign              bool              `yaml:"assign,omitempty"`
 	StaleTime           int               `yaml:"stale_time,omitempty"`
 	CatsEnabled         bool              `yaml:"cats_enabled,omitempty"`
 	DogsEnabled         bool              `yaml:"dogs_enabled,omitempty"`

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -56,6 +56,9 @@ func TestLoadConfig(t *testing.T) {
 	t.Run("Test Loading Config - VerifiedCommitCheckEnabled", func(t *testing.T) {
 		assert.Equal(t, true, paulConfig.PullRequests.VerifiedCommitCheck)
 	})
+	t.Run("Test Loading Config - Assign", func(t *testing.T) {
+		assert.Equal(t, true, paulConfig.PullRequests.Assign)
+	})
 }
 
 func TestLoadConfigFails(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Spazzy <brendankamp757@gmail.com>

# Changelog

- adds the assign command that assigns reviewers to pull requests e.g. `/assign @Spazzy757 `

## Issues

fix: https://github.com/Spazzy757/paul/issues/131
